### PR TITLE
Ensure constant sync in file audio source

### DIFF
--- a/barc/file_audio_source.cc
+++ b/barc/file_audio_source.cc
@@ -119,6 +119,10 @@ int file_audio_source_get_next(struct file_audio_source_s* pthis,
   return ret;
 }
 
+double file_audio_source_get_sample_rate(struct file_audio_source_s* pthis) {
+  return pthis->codec_context->time_base.den;
+}
+
 #pragma mark - Internal utilities
 
 static int open_file_stream(struct file_audio_source_s* pthis)

--- a/barc/file_audio_source.h
+++ b/barc/file_audio_source.h
@@ -21,7 +21,7 @@ int file_audio_source_load_config(struct file_audio_source_s* source,
 int file_audio_source_seek(struct file_audio_source_s* source, double to_time);
 double file_audio_source_get_pos(struct file_audio_source_s* source);
 int file_audio_source_get_next(struct file_audio_source_s* source,
-                               int num_samples,
-                               int16_t* samples);
+                               int num_samples, int16_t* samples);
+double file_audio_source_get_sample_rate(struct file_audio_source_s* source);
 
 #endif /* file_audio_source_h */

--- a/barc/main.c
+++ b/barc/main.c
@@ -28,8 +28,8 @@ int main(int argc, char **argv)
     char* manifest_supplemental = NULL;
     int out_width = 0;
     int out_height = 0;
-    int64_t begin_offset = -1;
-    int64_t end_offset = -1;
+    int64_t begin_offset = 0;
+    int64_t end_offset = 0;
     int c;
 
     static struct option long_options[] =


### PR DESCRIPTION
Also, don't hardcode a 1 second delay in the media tracks. :-|